### PR TITLE
IonicSideMenuDelegate: Fix compilation error.

### DIFF
--- a/src/ionic/sidemenu/IonicSideMenuDelegate.hx
+++ b/src/ionic/sidemenu/IonicSideMenuDelegate.hx
@@ -14,6 +14,6 @@ extern class IonicSideMenuDelegate {
 	public function isOpenLeft() : Bool;
 	public function isOpenRight() : Bool;
 	public function canDragContent(?canDrag : Bool) : Bool;
-	public function edgeDragThreshold(value : haxe.EitherType<Boolean, Int>) : Bool;
+	public function edgeDragThreshold(value : haxe.extern.EitherType<Bool, Int>) : Bool;
 	@:native("$getByHandle") public function getByHandle(handle : String) : IonicSideMenuDelegate;
 }


### PR DESCRIPTION
This change will fix a compilation error with Haxe 3.2.1.
