### PR TITLE
IonicModalController: Remove 'static' modifier from methods and fix 'show' method signature.

### DIFF
--- a/src/ionic/modal/IonicModal.hx
+++ b/src/ionic/modal/IonicModal.hx
@@ -18,9 +18,9 @@ typedef IonicModalControllerOptions = {
 
 @:native("ionicModal")
 extern class IonicModalController {
-	public static function initialize(options : IonicModalControllerOptions) : Void;
-	public static function show(event : Dynamic) : Promise<Dynamic>;
-	public static function hide() : Promise<Dynamic>;
-	public static function remove() : Promise<Dynamic>;
-	public static function isShown() : Bool;
+	public function initialize(options : IonicModalControllerOptions) : Void;
+	public function show() : Promise<Dynamic>;
+	public function hide() : Promise<Dynamic>;
+	public function remove() : Promise<Dynamic>;
+	public function isShown() : Bool;
 }


### PR DESCRIPTION
Hi,

the official documentation of [ionicModal](http://ionicframework.com/docs/api/controller/ionicModal/) (release 1.3.0) states the `$ionicModal` service creates _instances_ of `ionicModal`. So it seems like the methods should be instance methods, too. Also, the 'show' method signature does not list any arguments. This is why I removed the `static` modifiers from all methods and the `event` parameter from the `show` method. I tested these changes with my code and everything seems to work nicely.

Best regards
Jonny
